### PR TITLE
Add security rule and some other enhancements

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -154,12 +154,52 @@ metadata:
   description: "Clear explanation" # Required for understanding
 ```
 
+**Security Rules Requirements:**
+For security-related rules, additional metadata fields are required:
+- **OWASP and CWE classifications**: Include relevant OWASP Top 10 categories and CWE identifiers when applicable
+- **Security tags**: Always include "security" and "vulnerability" tags for security rules
+- **Example security rule metadata** (replace placeholders with appropriate classifications for your specific rule):
+  ```yaml
+  metadata:
+    author: "contributor-username"
+    tags: "security,vulnerability,injection"
+    description: "Detects potential security vulnerabilities"
+    owasp:
+      - "AXX:YYYY - Category Name"  # Replace with relevant OWASP classification
+    cwe:
+      - "CWE-ID: Description"       # Replace with relevant CWE classification
+  ```
+
 **Tag Categories:**
 - **Security**: authentication, injection, validation, etc.
 - **Performance**: optimization, memory, efficiency
 - **Best Practices**: style, maintainability, design
 - **Error Handling**: exceptions, validation, resilience
 - **Code Quality**: complexity, duplication, readability
+
+### 8.1 Testing with Context-Sherpa MCP Server
+
+**When the context-sherpa MCP server is available, AI agents should use it for enhanced rule testing:**
+
+The `context-sherpa` MCP server provides the `scan_path` tool which is ideal for testing rules against their test directories:
+
+```yaml
+# Example usage for testing a specific rule's test cases
+scan_path:
+  path: "ast-grep/tests/go/security/rule-name/"
+```
+
+**Benefits of MCP Server Testing:**
+- **Integrated Testing**: Test rules directly against their designated test directories
+- **Multiple File Support**: Efficiently scan entire test directories containing both valid and invalid examples
+- **Consistent Environment**: Ensures rules work correctly in the project's testing environment
+- **Early Validation**: Catch issues before manual testing or CLI-based validation
+
+**When to Use MCP Server Testing:**
+- After creating or modifying rules
+- When validating rule effectiveness against test cases
+- Before finalizing rule contributions
+- For regression testing when updating existing rules
 
 ## Contribution Workflow
 
@@ -171,7 +211,8 @@ metadata:
 4. **Write Rule YAML**: Follow exact structure requirements
 5. **Create Test Cases**: Both valid and invalid examples
 6. **Validate Locally**: Test with ast-grep CLI if possible
-7. **Document Clearly**: Explain what the rule does and why it matters
+7. **Test with MCP Server**: If context-sherpa MCP server is available, use `scan_path` tool to validate rule against test cases
+8. **Document Clearly**: Explain what the rule does and why it matters
 
 ### 10. Common Pitfalls to Avoid
 
@@ -203,6 +244,17 @@ ast-grep scan --rule path/to/rule.yml --debug
 
 # Check for existing similar rules
 ast-grep scan --rule path/to/rule.yml path/to/existing/files/
+```
+
+**For MCP server testing (when context-sherpa is available):**
+
+```yaml
+# Example: Test a rule using context-sherpa MCP server
+use_mcp_tool:
+  server_name: "context-sherpa"
+  tool_name: "scan_path"
+  arguments:
+    path: "ast-grep/tests/go/security/rule-name/"
 ```
 
 ## Success Criteria

--- a/ast-grep/rules/go/security/insecure-cgi-module.yml
+++ b/ast-grep/rules/go/security/insecure-cgi-module.yml
@@ -1,0 +1,21 @@
+id: ast-grep-go-security-insecure-cgi-module
+language: go
+message: "Avoid using net/http/cgi package due to vulnerability to httpoxy attacks (CVE-2015-5386)"
+severity: warning
+metadata:
+  author: context-sherpa
+  tags: security, vulnerability, httpoxy, cgi
+  description: "Detects usage of the vulnerable net/http/cgi package which is susceptible to httpoxy attacks"
+  owasp:
+    - A03:2017 - Sensitive Data Exposure
+    - A02:2021 - Cryptographic Failures
+  cwe:
+    - "CWE-327: Use of a Broken or Risky Cryptographic Algorithm"
+rule:
+  any:
+    - pattern: |
+        import "net/http/cgi"
+      kind: import_spec
+    - pattern: |
+        cgi.$FUNC(...)
+      kind: call_expression

--- a/ast-grep/rules/go/security/no-sprintf-in-db-call.yml
+++ b/ast-grep/rules/go/security/no-sprintf-in-db-call.yml
@@ -8,8 +8,8 @@ metadata:
   description: "Detects the use of fmt.Sprintf in database calls, which is a common SQL injection vulnerability."
 rule:
   any:
-    - pattern: $DB.Exec(ctx, fmt.Sprintf($$$))
-    - pattern: $DB.ExecContext(ctx, fmt.Sprintf($$$))
-    - pattern: $DB.Query(ctx, fmt.Sprintf($$$))
-    - pattern: $DB.QueryRow(ctx, fmt.Sprintf($$$))
-    - pattern: $DB.QueryRowContext(ctx, fmt.Sprintf($$$))
+    - pattern: $DB.Exec($$$, fmt.Sprintf($$$))
+    - pattern: $DB.ExecContext($$$, fmt.Sprintf($$$))
+    - pattern: $DB.Query($$$, fmt.Sprintf($$$))
+    - pattern: $DB.QueryRow($$$, fmt.Sprintf($$$))
+    - pattern: $DB.QueryRowContext($$$, fmt.Sprintf($$$))

--- a/ast-grep/rules/go/security/unchecked-error.yml
+++ b/ast-grep/rules/go/security/unchecked-error.yml
@@ -12,8 +12,8 @@ rule:
         $ERR := $FUNC( $$$ )
     - not:
         any:
-          - pattern: |
-              $ERR := $FUNC( $$$ )
-              if $ERR != nil {
+          - follows:
+              pattern: |
+                if $ERR != nil {
           - pattern: |
               if $ERR := $FUNC( $$$ ); $ERR != nil {

--- a/ast-grep/tests/go/security/insecure-cgi-module/invalid.go
+++ b/ast-grep/tests/go/security/insecure-cgi-module/invalid.go
@@ -1,0 +1,20 @@
+package main
+
+import (
+	"net/http"
+	"net/http/cgi"
+)
+
+// First bad example - uses cgi.Serve
+func badExample() {
+	// ruleid: insecure-cgi-module
+	// This should trigger the rule - uses net/http/cgi import and cgi.Serve
+	cgi.Serve(http.FileServer(http.Dir("/usr/share/doc")))
+}
+
+// Second bad example - uses cgi.Serve with different parameters
+func anotherBadExample() {
+	// ruleid: insecure-cgi-module
+	// This should also trigger the rule - uses cgi.Serve function
+	cgi.Serve(http.FileServer(http.Dir("/tmp")))
+}

--- a/ast-grep/tests/go/security/insecure-cgi-module/valid.go
+++ b/ast-grep/tests/go/security/insecure-cgi-module/valid.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"crypto/cipher"
+	"crypto/des"
+	"crypto/md5"
+	"crypto/rand"
+	"crypto/rc4"
+	"crypto/sha1"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"os"
+)
+
+func goodExample() {
+	// This should not trigger the rule - no cgi usage
+	block, err := des.NewCipher([]byte("sekritz"))
+	if err != nil {
+		panic(err)
+	}
+	plaintext := []byte("I CAN HAZ SEKRIT MSG PLZ")
+	ciphertext := make([]byte, des.BlockSize+len(plaintext))
+	iv := ciphertext[:des.BlockSize]
+	if _, err := io.ReadFull(rand.Reader, iv); err != nil {
+		panic(err)
+	}
+	stream := cipher.NewCFBEncrypter(block, iv)
+	stream.XORKeyStream(ciphertext[des.BlockSize:], plaintext)
+	fmt.Println("Secret message is: %s", hex.EncodeToString(ciphertext))
+}
+
+func anotherGoodExample() {
+	for _, arg := range os.Args {
+		// This should not trigger the rule - no cgi usage
+		fmt.Printf("%x - %s\n", md5.Sum([]byte(arg)), arg)
+	}
+}
+
+func thirdGoodExample() {
+	// This should not trigger the rule - no cgi usage
+	cipher, err := rc4.NewCipher([]byte("sekritz"))
+	if err != nil {
+		panic(err)
+	}
+	plaintext := []byte("I CAN HAZ SEKRIT MSG PLZ")
+	ciphertext := make([]byte, len(plaintext))
+	cipher.XORKeyStream(ciphertext, plaintext)
+	fmt.Println("Secret message is: %s", hex.EncodeToString(ciphertext))
+}
+
+func fourthGoodExample() {
+	for _, arg := range os.Args {
+		// This should not trigger the rule - no cgi usage
+		fmt.Printf("%x - %s\n", sha1.Sum([]byte(arg)), arg)
+	}
+}

--- a/index.json
+++ b/index.json
@@ -33,6 +33,22 @@
       ]
     },
     {
+      "id": "ast-grep-go-security-insecure-cgi-module",
+      "tool": "ast-grep",
+      "path": "rules/go/security/insecure-cgi-module.yml",
+      "language": "go",
+      "author": "context-sherpa",
+      "message": "Avoid using net/http/cgi package due to vulnerability to httpoxy attacks (CVE-2015-5386)",
+      "severity": "warning",
+      "description": "Detects usage of the vulnerable net/http/cgi package which is susceptible to httpoxy attacks",
+      "tags": [
+        "security",
+        "vulnerability",
+        "httpoxy",
+        "cgi"
+      ]
+    },
+    {
       "id": "go-no-sprintf-in-db-call",
       "tool": "ast-grep",
       "path": "rules/go/security/no-sprintf-in-db-call.yml",

--- a/sgconfig.yml
+++ b/sgconfig.yml
@@ -1,0 +1,2 @@
+ruleDirs:
+  - ast-grep/rules


### PR DESCRIPTION
- add new rule for use of insecure cgi module
- enhanced no-sprintf-in-db-call rule
- enhanced agent rules
- added `sgconfig.yml` so `ast-grep` or the context sherpa mcp server can be used from the project directory to scan